### PR TITLE
PC/スマホのフィルタバー調整＋更新ボタン削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,32 +79,38 @@
             <button class="chip" data-cat="他団体">他団体</button>
             
             <button class="chip" data-cat="その他">その他</button>
-        </div>
-        
-        <div class="filter-controls">
             <label class="toggle-switch">
                 <input type="checkbox" id="multi-select-toggle">
                 <span class="slider"></span>
                 <span class="label-text">複数選択</span>
             </label>
+        </div>
+        
+        <div class="filter-controls">
             
-            <label class="sort-controls">
-                <span class="label-text">ソート:</span>
-                <select id="sort-method-select" class="sort-select">
-                    <option value="tag">タグ順</option>
-                    <option value="updated">更新順</option>
-                    <option value="reading">名前（読み）</option>
-                </select>
-                <select id="sort-order-select" class="sort-select">
-                    <option value="asc">昇順</option>
-                    <option value="desc">降順</option>
-                </select>
-            </label>
-                <button id="reload-sheet-btn" class="reload-btn">再読み込み</button>
-
             <button id="filter-expand-btn" class="filter-toggle-btn">
                 <span class="btn-text">タグをすべて見る</span>
                 <span class="btn-icon">▼</span>
+            </button>
+            
+            <div class="sort-controls-wrapper">
+                <label class="sort-controls">
+                    <span class="label-text">ソート:</span>
+                    <select id="sort-method-select" class="sort-select">
+                        <option value="tag">タグ順</option>
+                        <option value="updated">更新順</option>
+                        <option value="reading">名前（読み）</option>
+                    </select>
+                    <select id="sort-order-select" class="sort-select">
+                        <option value="asc">昇順</option>
+                        <option value="desc">降順</option>
+                    </select>
+                </label>
+            </div>
+            
+            <button id="filter-close-btn" class="filter-toggle-btn" style="display:none;">
+                <span class="btn-text">閉じる</span>
+                <span class="btn-icon">▲</span>
             </button>
         </div>
         

--- a/script.js
+++ b/script.js
@@ -141,6 +141,9 @@ function setupEventListeners() {
         } else {
             textSpan.textContent = 'タグをすべて見る';
         }
+
+        // 展開状態を変えたらオーバーフロー判定を更新
+        checkTagOverflow();
     };
     
     if(expandBtn && tagContainer) {
@@ -358,21 +361,35 @@ function renderList() {
 function checkTagOverflow() {
     const tagContainer = document.getElementById('tag-container');
     const expandBtn = document.getElementById('filter-expand-btn');
-    if (!tagContainer || !expandBtn) return;
+    const filterBar = document.querySelector('.filter-bar');
+    if (!tagContainer || !expandBtn || !filterBar) return;
+
+    // PC では常に展開表示なのでスマホのみ判定
+    const isDesktop = window.matchMedia('(min-width: 768px)').matches;
+    if (isDesktop) {
+        filterBar.classList.remove('collapsed-overflow');
+        return;
+    }
     
-    // 一度閉じた状態で判定する
+    // 計測時はいったん閉じる
     const wasExpanded = tagContainer.classList.contains('expanded');
     tagContainer.classList.remove('expanded');
     
-    // 1px余裕を見る
+    // 1px 余裕を持ってオーバーフロー判定
     const hasOverflow = tagContainer.scrollWidth > tagContainer.clientWidth + 1;
+
+    // オーバーフローしていて未展開なら、トグルを固定表示させるフラグを付与
+    const shouldPinToggle = hasOverflow && !wasExpanded;
+    filterBar.classList.toggle('collapsed-overflow', shouldPinToggle);
     
     if (hasOverflow) {
         expandBtn.style.display = 'flex';
-        if (wasExpanded) tagContainer.classList.add('expanded');
     } else {
         expandBtn.style.display = 'none';
     }
+
+    // 元の展開状態を復元
+    if (wasExpanded) tagContainer.classList.add('expanded');
 }
 
 window.searchByTag = function(e, tag) {

--- a/script.js
+++ b/script.js
@@ -71,45 +71,6 @@ async function init() {
         console.error(e);
         if(listContainer) listContainer.innerHTML = '<li style="color:red;padding:20px">データ読込エラー</li>';
     }
-    // 自動ポーリング開始（30秒ごと）。既にある場合はクリア
-    try {
-        if (window._sheetPollInterval) clearInterval(window._sheetPollInterval);
-
-        const getMaxTimestamp = (arr) => {
-            if (!Array.isArray(arr) || arr.length === 0) return -Infinity;
-            const keys = ['updated', 'updated_at', 'updatedAt', 'modified', 'modified_at', 'date', 'timestamp'];
-            let max = -Infinity;
-            for (const it of arr) {
-                for (const k of keys) {
-                    if (it && it[k]) {
-                        const t = Date.parse(it[k]);
-                        if (!isNaN(t) && t > max) max = t;
-                        break; // found a timestamp-like key for this item
-                    }
-                }
-            }
-            return max;
-        };
-
-        window._sheetPollInterval = setInterval(async () => {
-            try {
-                if (window.reloadSheet) {
-                    const prevMax = getMaxTimestamp(termsData || []);
-                    await window.reloadSheet(true);
-                    const newMax = getMaxTimestamp(window.termsData || []);
-                    if (newMax > prevMax) {
-                        termsData = window.termsData;
-                        renderHomeFavorites();
-                        if (viewResults.classList.contains('active')) renderList();
-                    }
-                }
-            } catch (err) {
-                console.warn('poll reload failed:', err);
-            }
-        }, 30000);
-    } catch (e) {
-        console.warn('could not start poll:', e);
-    }
 }
 
 // --- 2. イベント設定 ---
@@ -133,7 +94,6 @@ function setupEventListeners() {
     // ソート選択の変化でリストを再描画
     if (sortMethodSelect) sortMethodSelect.addEventListener('change', () => renderList());
     if (sortOrderSelect) sortOrderSelect.addEventListener('change', () => renderList());
-    const reloadBtn = document.getElementById('reload-sheet-btn');
     // ソート方式に応じて右側のラベルを切り替える
     function updateSortOrderLabels() {
         if (!sortMethodSelect || !sortOrderSelect) return;
@@ -155,24 +115,6 @@ function setupEventListeners() {
     if (sortMethodSelect) sortMethodSelect.addEventListener('change', () => { updateSortOrderLabels(); renderList(); });
     // 初期ラベル更新
     updateSortOrderLabels();
-    if (reloadBtn) reloadBtn.addEventListener('click', async () => {
-        reloadBtn.disabled = true;
-        reloadBtn.textContent = '再読み込み中…';
-        try {
-            if (window.reloadSheet) await window.reloadSheet(true);
-            // 更新されたデータをローカルに取り込んで再描画
-            if (window.termsData && Array.isArray(window.termsData)) {
-                termsData = window.termsData;
-                renderHomeFavorites();
-                if (viewResults.classList.contains('active')) renderList();
-            }
-        } catch (e) {
-            console.error(e);
-        } finally {
-            reloadBtn.disabled = false;
-            reloadBtn.textContent = '再読み込み';
-        }
-    });
 
     const showAllListBtn = document.getElementById('show-all-link');
     if(showAllListBtn) {
@@ -184,18 +126,28 @@ function setupEventListeners() {
 
     // タグエリアの開閉ボタン
     const expandBtn = document.getElementById('filter-expand-btn');
+    const closeBtn = document.getElementById('filter-close-btn');
     const tagContainer = document.getElementById('tag-container');
+    const filterBar = document.querySelector('.filter-bar');
+    
+    const toggleExpanded = () => {
+        tagContainer.classList.toggle('expanded');
+        if(filterBar) filterBar.classList.toggle('expanded');
+        
+        // ボタンのテキストを切り替え
+        const textSpan = expandBtn.querySelector('.btn-text');
+        if(tagContainer.classList.contains('expanded')) {
+            textSpan.textContent = '閉じる';
+        } else {
+            textSpan.textContent = 'タグをすべて見る';
+        }
+    };
+    
     if(expandBtn && tagContainer) {
-        expandBtn.addEventListener('click', () => {
-            tagContainer.classList.toggle('expanded');
-            
-            const textSpan = expandBtn.querySelector('.btn-text');
-            if(tagContainer.classList.contains('expanded')) {
-                textSpan.textContent = '閉じる';
-            } else {
-                textSpan.textContent = 'タグをすべて見る';
-            }
-        });
+        expandBtn.addEventListener('click', toggleExpanded);
+    }
+    if(closeBtn && tagContainer) {
+        closeBtn.addEventListener('click', toggleExpanded);
     }
     // リサイズ時にもあふれチェック
     window.addEventListener('resize', checkTagOverflow);

--- a/style.css
+++ b/style.css
@@ -305,6 +305,19 @@ body {
 .toggle-switch input:checked + .slider::before { transform: translateX(16px); }
 .toggle-switch input:checked ~ .label-text { color: var(--primary); }
 
+/* スマホでタグが折り込まれるときはトグルを左下に固定表示 */
+.filter-bar.collapsed-overflow .toggle-switch {
+    position: absolute;
+    left: 12px;
+    bottom: 10px;
+    transform: none;
+    background: var(--white);
+    padding: 4px 8px;
+    border-radius: 14px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    z-index: 2;
+}
+
 
 /* チップ */
 .chip { padding: 6px 14px; border-radius: 6px; font-size: 13px; border: 1px solid #eee; background: var(--white); color: var(--text-sub); white-space: nowrap; cursor: pointer; transition: 0.2s; user-select: none; flex-shrink: 0; font-family: inherit; line-height: inherit; appearance: none; }

--- a/style.css
+++ b/style.css
@@ -142,33 +142,131 @@ body {
 /* ▼▼▼ コントロールエリア（スイッチと開閉ボタン） ▼▼▼ */
 .filter-controls {
     display: flex;
+    flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     width: 100%;
+}
+
+/* タグをすべて見るボタンを右側に寄せる */
+#filter-expand-btn { margin-left: auto; }
+
+/* ソート関連ラッパー: スマホでは初期非表示、タグ展開時に表示 */
+.sort-controls-wrapper {
+    display: none; /* スマホでは初期非表示 */
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+    width: 100%;
+}
+
+/* 閉じるボタンは初期非表示 */
+#filter-close-btn {
+    display: none;
+}
+
+/* タグ展開時のレイアウト: タグ一覧＋複数選択→線→ソート→線→閉じる */
+.filter-bar.expanded .filter-controls {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+/* タグエリアを相対配置にして、複数選択を絶対配置可能に */
+.filter-bar.expanded .categories-scroll {
+    position: relative;
+    padding-bottom: 12px;
+    margin-bottom: 0;
+    /* 中央揃えは維持（justify-content: center） */
+}
+
+/* 複数選択をタグ列の下の行・左側に配置 */
+.filter-bar.expanded .toggle-switch {
+    order: 999;           /* タグ群の後ろに回す */
+    flex-basis: 100%;     /* 新しい行を占有 */
+    display: inline-flex;
+    align-items: center;
+    margin-top: 6px;
+}
+
+/* タグエリア全体の下に線 */
+.filter-bar.expanded .categories-scroll::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: #e0e0e0;
+}
+
+/* ソート */
+.filter-bar.expanded .sort-controls-wrapper {
+    display: flex;
+    order: 1;
+    padding: 12px 0;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+/* 閉じるボタン */
+.filter-bar.expanded #filter-expand-btn {
+    order: 2;
+    padding-top: 8px;
+    justify-content: flex-end;
+}
+
+/* 展開時は「タグをすべて見る」のアイコンを上向きに */
+.filter-bar.expanded #filter-expand-btn .btn-icon {
+    transform: rotate(180deg);
+}
+
+/* デスクトップでは常時表示 */
+@media (min-width: 768px) {
+    /* PC: 上部固定。1行目=タグ（折り返し表示）、2行目=左:複数選択 右:ソート */
+    .filter-bar { position: sticky; top: var(--header-height); z-index: 105; padding-bottom: 0; }
+    .categories-scroll { flex-wrap: wrap; overflow-x: visible; justify-content: flex-start; max-height: none; margin-bottom: 10px; }
+    .filter-controls { position: relative; display: flex; align-items: center; gap: 12px; justify-content: flex-end; }
+    /* PCでは「タグをすべて見る」「閉じる」は非表示 */
+    #filter-expand-btn, #filter-close-btn { display: none !important; }
+    /* 複数選択を2行目の左端に配置（少し上にオフセット） */
+    .toggle-switch { position: absolute; left: 10px; bottom: 18px; margin: 0; padding: 0 !important; border: none; z-index: 1; }
+    .sort-controls-wrapper { display: flex !important; width: auto; padding: 0 !important; border-bottom: none !important; margin-left: auto; align-items: center; }
 }
 
 /* ソート関連コントロールの調整: タグやカードと雰囲気を合わせる */
 .sort-controls {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
+    flex-wrap: nowrap;
+}
+
+.sort-controls .label-text {
+    white-space: nowrap;
+    font-size: 12px;
+    flex-shrink: 0;
 }
 
 .sort-select {
-    padding: 6px 10px;
-    border-radius: 10px;
-    border: 1px solid #eee;
-    background: var(--white);
+    padding: 8px 12px;
+    border-radius: 12px;
+    border: 1px solid #dbe4ff;
+    background: linear-gradient(180deg, #fafdff 0%, #f3f7ff 100%);
     color: var(--text-main);
     font-size: 13px;
     cursor: pointer;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.03);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.06);
     appearance: none;
+    min-width: 0;
+    flex-shrink: 1;
+    transition: box-shadow 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
 }
 .sort-select:focus {
     outline: none;
     border-color: var(--primary);
-    box-shadow: 0 6px 18px rgba(0,86,179,0.08);
+    box-shadow: 0 8px 24px rgba(0,86,179,0.12);
+    transform: translateY(-1px);
 }
 
 /* ドロップダウンであることが視認できるよう、右端に逆三角アイコンを表示 */
@@ -180,29 +278,14 @@ body {
     padding-right: 36px; /* アイコン分の余白を確保 */
 }
 
-/* 再読み込みボタンをカード／チップの雰囲気に合わせる */
-.reload-btn {
-    padding: 8px 12px;
-    border-radius: 10px;
-    border: 1px solid #eee;
-    background: var(--white);
+/* ドロップダウンリストの色味を合わせる（対応ブラウザ限定） */
+.sort-select option {
+    background: #ffffff;
     color: var(--text-main);
-    font-weight: 700;
-    cursor: pointer;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.04);
-    transition: transform 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
-.reload-btn:hover {
-    transform: translateY(-2px);
-    border-color: var(--primary);
+.sort-select option:checked {
+    background: var(--primary-bg);
     color: var(--primary);
-}
-.reload-btn:active { transform: translateY(0); opacity: 0.95; }
-
-/* 小さい画面でレイアウトが窮屈なら折り返す */
-@media (max-width: 520px) {
-    .filter-controls { flex-direction: column; align-items: stretch; gap: 8px; }
-    .sort-controls { justify-content: space-between; }
 }
 
 .filter-toggle-btn {
@@ -214,7 +297,7 @@ body {
 .categories-scroll.expanded + .filter-controls .btn-icon { transform: rotate(180deg); } /* divを経由してアイコンを回転させるセレクタだと少し複雑になるため、JSでクラス付与か、シンプルに回転なしでもOKですが、必要ならJSでボタンにクラスを付けたほうが確実です */
 
 /* スイッチのデザイン */
-.toggle-switch { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 11px; color: var(--text-sub); font-weight: bold; }
+.toggle-switch { display: flex; align-items: center; transform: translateY(8px); cursor: pointer; font-size: 11px; color: var(--text-sub); font-weight: bold; }
 .toggle-switch input { display: none; }
 .slider { position: relative; width: 36px; height: 20px; background-color: #e0e0e0; border-radius: 20px; transition: 0.3s; }
 .slider::before { content: ""; position: absolute; height: 16px; width: 16px; left: 2px; bottom: 2px; background-color: white; border-radius: 50%; transition: 0.3s; box-shadow: 0 2px 4px rgba(0,0,0,0.2); }


### PR DESCRIPTION
PCレイアウト: 1行目：タグ行、2行目：複数選択(左)、ソート(右)
スマホレイアウト: ソートはタグ展開時のみ表示。展開時は「タグ一覧→複数選択→区切り線→ソート→区切り線→閉じる」の順で整列し、はみ出しを解消。 更新ボタン削除: 更新ボタンのHTML要素・関連JS処理・CSSスタイルを削除。