### PR TITLE
グーグルフォームへ遷移するリンクボタンの表示変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             <button id="map-fab-btn" class="map-fab-btn" aria-label="地図を開く">🗺️</button>
         </div>
         <div class="home-footer">
-            <a href="https://forms.gle/VD1gYno9abitxcDK7" target="_blank" rel="noopener noreferrer" class="text-link-btn">⚠️ 用語追加・不具合報告はこちら</a>
+            <a href="https://forms.gle/VD1gYno9abitxcDK7" target="_blank" rel="noopener noreferrer" class="text-link-btn">ご意見・お問い合わせはこちらから</a>
         </div>
     </div>
 


### PR DESCRIPTION
<img width="1512" height="829" alt="image" src="https://github.com/user-attachments/assets/ac17fd36-de64-46d3-a749-77a5d59be85a" />

グーグルフォームへ遷移するリンクボタンの表示変更